### PR TITLE
ダークモードの導入（next-themeの追加）

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "next": "10.0.5",
+    "next-themes": "^0.0.10",
     "react": "17.0.1",
     "react-dom": "17.0.1"
   },

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -6,7 +6,7 @@ export const Layout = (props: { children: ReactNode }) => {
   return (
     <>
       <Header />
-      <main className="bg-red-100">{props.children}</main>
+      <main className="bg-red-100 dark:bg-gray-800 dark:text-white">{props.children}</main>
       <Footer />
     </>
   );

--- a/src/components/sample/themeChangerSample.tsx
+++ b/src/components/sample/themeChangerSample.tsx
@@ -9,19 +9,16 @@ const ThermeChangerSample: VFC = () => {
     setIsMounted(true);
   }, []);
 
+  if (!isMounted) return null;
   const swithchTheme = () => {
-    if (isMounted) {
-      setTheme(theme === "light" ? "dark" : "light");
-    }
+    setTheme(theme === "light" ? "dark" : "light");
   };
 
-  if (!isMounted) return null;
   return (
     <button
       onClick={swithchTheme}
       type="button"
-      className="bg-gray-200     text-gray-700   hover:bg-gray-300 px-4 py-2 m-2 ease select-none　focus:shadow-outline
-                dark:bg-blue-800 dark:text-white dark:hover:bg-blue-900"
+      className="bg-gray-200 text-gray-700 hover:bg-gray-300 px-4 py-2 m-2 ease select-none　focus:shadow-outline dark:bg-blue-800 dark:text-white dark:hover:bg-blue-900"
     >
       {theme}
     </button>

--- a/src/components/sample/themeChangerSample.tsx
+++ b/src/components/sample/themeChangerSample.tsx
@@ -1,0 +1,30 @@
+import { useTheme } from "next-themes";
+import type { VFC } from "react";
+import { useEffect, useState } from "react";
+
+const ThermeChangerSample: VFC = () => {
+  const [isMounted, setIsMounted] = useState(false);
+  const { theme, setTheme } = useTheme();
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  const swithchTheme = () => {
+    if (isMounted) {
+      setTheme(theme === "light" ? "dark" : "light");
+    }
+  };
+
+  if (!isMounted) return null;
+  return (
+    <button
+      onClick={swithchTheme}
+      type="button"
+      className="bg-gray-200     text-gray-700   hover:bg-gray-300 px-4 py-2 m-2 ease select-none　focus:shadow-outline
+                dark:bg-blue-800 dark:text-white dark:hover:bg-blue-900"
+    >
+      {theme}
+    </button>
+  );
+};
+export { ThermeChangerSample };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,14 @@
 import "src/styles/global.css";
 
 import type { AppProps } from "next/app";
+import { ThemeProvider } from "next-themes";
 
 const App = (props: AppProps) => {
-  return <props.Component {...props.pageProps} />;
+  return (
+    <ThemeProvider value={{ dark: "dark", light: "light" }} disableTransitionOnChange>
+      <props.Component {...props.pageProps} />;
+    </ThemeProvider>
+  );
 };
 
 export default App;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,7 +5,7 @@ import { ThemeProvider } from "next-themes";
 
 const App = (props: AppProps) => {
   return (
-    <ThemeProvider value={{ dark: "dark", light: "light" }} disableTransitionOnChange>
+    <ThemeProvider attribute="class" disableTransitionOnChange>
       <props.Component {...props.pageProps} />;
     </ThemeProvider>
   );

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,7 +6,7 @@ import { ThemeProvider } from "next-themes";
 const App = (props: AppProps) => {
   return (
     <ThemeProvider attribute="class" disableTransitionOnChange>
-      <props.Component {...props.pageProps} />;
+      <props.Component {...props.pageProps} />
     </ThemeProvider>
   );
 };

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -12,7 +12,7 @@ class MyDocument extends Document {
         <Head>
           <meta name="description" content="Hello, World!" />
         </Head>
-        <body>
+        <body className="bg-white text-black dark:bg-black dark:text-white">
           <Main />
           <NextScript />
         </body>

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,7 +1,21 @@
 import Head from "next/head";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
 import { Layout } from "src/components/layout";
 
 const About = () => {
+  const [mounted, setMounted] = useState(false);
+  const { theme, setTheme } = useTheme();
+
+  useEffect(() => {
+    return setMounted(true);
+  }, []);
+
+  const handleThemeChange = (value: string) => {
+    setTheme(value);
+  };
+  if (!mounted) return null;
+
   return (
     <Layout>
       <Head>
@@ -9,6 +23,22 @@ const About = () => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <h2>About</h2>
+      <p>the current theme is: {theme}</p>
+      <select
+        onBlur={(selectedOptinon) => {
+          return handleThemeChange(selectedOptinon.target.value);
+        }}
+        onChange={(selectedOptinon) => {
+          return handleThemeChange(selectedOptinon.target.value);
+        }}
+      >
+        <option selected={theme === "dark"} value="dark">
+          Dark
+        </option>
+        <option selected={theme === "light"} value="light">
+          Light
+        </option>
+      </select>
     </Layout>
   );
 };

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,22 +1,9 @@
 import Head from "next/head";
-import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
 import { Layout } from "src/components/layout";
 import { ClsxSample } from "src/components/sample/clsxSample";
+import { ThermeChangerSample } from "src/components/sample/themeChangerSample";
 
 const About = () => {
-  const [mounted, setMounted] = useState(false);
-  const { theme, setTheme } = useTheme();
-
-  useEffect(() => {
-    return setMounted(true);
-  }, []);
-
-  const handleThemeChange = (value: string) => {
-    setTheme(value);
-  };
-  if (!mounted) return null;
-
   return (
     <Layout>
       <Head>
@@ -24,25 +11,9 @@ const About = () => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <h2>About</h2>
-
-      <p>the current theme is: {theme}</p>
-      <select
-        onBlur={(selectedOptinon) => {
-          return handleThemeChange(selectedOptinon.target.value);
-        }}
-        onChange={(selectedOptinon) => {
-          return handleThemeChange(selectedOptinon.target.value);
-        }}
-      >
-        <option selected={theme === "dark"} value="dark">
-          Dark
-        </option>
-        <option selected={theme === "light"} value="light">
-          Light
-        </option>
-      </select>
       <ClsxSample>clsxサンプル</ClsxSample>
       <ClsxSample bold>clsxサンプル(propsに応じてスタイル変更)</ClsxSample>
+      <ThermeChangerSample />
     </Layout>
   );
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,3 +9,16 @@ body {
 main {
   background-color: peachpuff;
 }
+select {
+  font-size: 30px;
+}
+
+/* Dark Mode確認用 */
+[data-theme="dark"] body {
+  margin: 0;
+  color: #fff;
+  background: #303030;
+}
+[data-theme="dark"] main {
+  background-color: #424242;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   purge: ["./src/**/*.{js,ts,jsx,tsx}"],
-  darkMode: "media", // 'media' or 'class'
+  darkMode: "class", // 'media' or 'class'
   theme: { extend: {} },
   variants: { extend: {} },
   plugins: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5118,6 +5118,11 @@ neo-async@^2.5.0, neo-async@^2.6.1, neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
+next-themes@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/next-themes/-/next-themes-0.0.10.tgz#86fe5f8a4654416f5d9157993217180174e582b8"
+  integrity sha512-YapL2GVJDooOuGYCYyCywYXRMpulBngG5Qay/HkMK9RyL9xOZ6C3vEgac2dzLWpo3uDVlk+0Qc9XgwGfLHwq/w==
+
 next-tick@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"


### PR DESCRIPTION
## ticket

- #9

## 対応内容

- [next-theme](https://github.com/pacocoursey/next-themes)の導入
- Aboutページにダークモードに変更するセレクタを追加
- 確認用としてglobal.cssにダークモード選択時の内容を記述

## メモ

- Tailwindを導入後に以下の変更が必要なようです。

  - tailwind.config.jsで、ダークモードプロバティをクラスに設定する。

  ```
  // tailwind.config.js
  module.exports = {
    darkMode: 'class'
  }
  ```

  - テーマプロパイダの属性をクラスに設定する。

  ```
  // pages/_app.js
  <ThemeProvider attribute="class">
  ```

  - サンプル

  ```
  <h1 className="text-black dark:text-white">
  ```

Tailwind使用したことがなかったので、間違えているかもしれないです・・

## キャプチャー
![image](https://user-images.githubusercontent.com/65271262/105207779-45872a80-5b8b-11eb-815b-2afea1003503.png)

## 確認したこと

- ページ遷移した際にダークモードが反映されるか。⇨されました。
- 1度ページを閉じた後に、再度開き直した場合に閉じる前の状態が保持されているか。⇨されました。
- 同一のブラウザ複数ウィンドウでテーマを変更した際に、全てのウィンドウで変更が反映されるか。⇨されました。
- 異なるブラウザでウィンドウテーマを変更した際に、全てのブラウザに変更が反映されるか⇨**されませんでした。**
ChromeとSafariにて確認しました。

PRするのが初めてのため、他の方のものを参考にさせていただきましたが、おかしな所など教えていただきたいです！
ご確認お願よろしくお願いします！