### PR TITLE
next-themesによるダークモードを実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "clsx": "^1.1.1",
     "next": "10.0.5",
+    "next-themes": "^0.0.10",
     "react": "17.0.1",
     "react-dom": "17.0.1"
   },

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,7 +1,9 @@
 export const Footer = () => {
   return (
-    <footer>
-      <small lang="en">@ 2021 memo.qin.sh</small>
+    <footer className="bg-white dark:bg-gray-800">
+      <small className="text-gray-800 dark:text-white" lang="en">
+        @ 2021 memo.qin.sh
+      </small>
     </footer>
   );
 };

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { useTheme } from "next-themes";
 
 const items = [
   { href: "/", label: "Home" },
@@ -6,18 +7,32 @@ const items = [
 ];
 
 export const Header = () => {
+  const { theme, setTheme } = useTheme();
   return (
     <header>
-      <h1>Title</h1>
-      <nav>
-        {items.map(({ href, label }) => {
-          return (
-            <Link key={href} href={href}>
-              <a style={{ display: "inline-block", padding: 12 }}>{label}</a>
-            </Link>
-          );
-        })}
-      </nav>
+      <div className="bg-white dark:bg-gray-800">
+        {" "}
+        <h1 className="text-gray-900 dark:text-white">Title</h1>
+        <button
+          className="text-white dark:text-gray-900 bg-gray-800 dark:bg-white"
+          onClick={() => {
+            setTheme(theme === "light" ? "dark" : "light");
+          }}
+        >
+          Change Theme
+        </button>
+        <nav>
+          {items.map(({ href, label }) => {
+            return (
+              <Link key={href} href={href}>
+                <a style={{ display: "inline-block", padding: 12 }} className="text-gray-800 dark:text-gray-100">
+                  {label}
+                </a>
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
     </header>
   );
 };

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -11,7 +11,6 @@ export const Header = () => {
   return (
     <header>
       <div className="bg-white dark:bg-gray-800">
-        {" "}
         <h1 className="text-gray-900 dark:text-white">Title</h1>
         <button
           className="text-white dark:text-gray-900 bg-gray-800 dark:bg-white"

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -6,7 +6,7 @@ export const Layout = (props: { children: ReactNode }) => {
   return (
     <>
       <Header />
-      <main className="bg-red-100">{props.children}</main>
+      <main className="bg-red-100 dark:bg-gray-700">{props.children}</main>
       <Footer />
     </>
   );

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,14 @@
 import "src/styles/global.css";
 
 import type { AppProps } from "next/app";
+import { ThemeProvider } from "next-themes";
 
 const App = (props: AppProps) => {
-  return <props.Component {...props.pageProps} />;
+  return (
+    <ThemeProvider attribute="class">
+      <props.Component {...props.pageProps} />
+    </ThemeProvider>
+  );
 };
 
 export default App;

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -9,7 +9,7 @@ const About = () => {
         <title>About</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <h2>About</h2>
+      <h2 className="text-gray-800 dark:text-white">About</h2>
       <ClsxSample>clsxサンプル</ClsxSample>
       <ClsxSample bold>clsxサンプル(propsに応じてスタイル変更)</ClsxSample>
     </Layout>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,8 +8,9 @@ const Home = () => {
         <title>Home</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <h2>Home</h2>
+      <h2 className="text-gray-800 dark:text-white">Home</h2>
       <button
+        className="text-gray-800 dark:text-white"
         onClick={() => {
           window.alert("Hello, World!");
         }}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   purge: ["./src/**/*.{js,ts,jsx,tsx}"],
-  darkMode: "media", // 'media' or 'class'
+  darkMode: "class", // 'media' or 'class'
   theme: { extend: {} },
   variants: { extend: {} },
   plugins: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5245,6 +5245,11 @@ neo-async@^2.5.0, neo-async@^2.6.1, neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
+next-themes@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/next-themes/-/next-themes-0.0.10.tgz#86fe5f8a4654416f5d9157993217180174e582b8"
+  integrity sha512-YapL2GVJDooOuGYCYyCywYXRMpulBngG5Qay/HkMK9RyL9xOZ6C3vEgac2dzLWpo3uDVlk+0Qc9XgwGfLHwq/w==
+
 next-tick@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"


### PR DESCRIPTION
#9 への対応

やったこと
- next-themesの導入 ([参考](https://github.com/pacocoursey/next-themes#install))
- Tailwindで使用するための設定 ([参考](https://github.com/pacocoursey/next-themes#with-tailwind))
- 動作テストのため、ヘッダーに切替ボタンを実装し、テーマが切り替わることを確認

初プルリクなので、やり方等問題ありましたらご指摘下さい！
ご確認よろしくお願いします！