### PR TITLE
🐛 ボタンの文言間違い訂正

### DIFF
--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -17,10 +17,10 @@ const Signin: NextPage = () => {
             <LogoIcon />
           </div>
           <Button button id="googleButton" bgColor="white" startIcon={<GoogleIcon />} size="large" className="w-72">
-            Googleでアカウント作成
+            Googleでログイン
           </Button>
           <Button button id="appleButton" bgColor="black" startIcon={<AppleIcon />} size="large" className="w-72">
-            Appleでアカウント作成
+            Appleでログイン
           </Button>
         </div>
       </div>


### PR DESCRIPTION
ボタンの文言が誤っていました。
誤り：Googleでアカウント作成
正解：Googleでログイン
Appleも同様です。