### PR TITLE
マイページ（設定）画面のコーディング

### DIFF
--- a/src/components/icon/ChevronRight.tsx
+++ b/src/components/icon/ChevronRight.tsx
@@ -6,12 +6,14 @@ type Props = {
 
 export const ChevronRight: VFC<Props> = (props) => {
   return (
-    <svg className={props.className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-      <path
-        fillRule="evenodd"
-        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-        clipRule="evenodd"
-      />
+    <svg
+      className={props.className}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
     </svg>
   );
 };

--- a/src/components/icon/ChevronRight.tsx
+++ b/src/components/icon/ChevronRight.tsx
@@ -2,7 +2,6 @@ import type { VFC } from "react";
 
 type Props = {
   className?: string;
-  disabled?: boolean;
 };
 
 export const ChevronRight: VFC<Props> = (props) => {
@@ -20,5 +19,4 @@ export const ChevronRight: VFC<Props> = (props) => {
 // Propsのデフォルト値
 ChevronRight.defaultProps = {
   className: "w-5 h-5",
-  disabled: false,
 };

--- a/src/components/icon/ChevronRight.tsx
+++ b/src/components/icon/ChevronRight.tsx
@@ -1,0 +1,24 @@
+import type { VFC } from "react";
+
+type Props = {
+  className?: string;
+  disabled?: boolean;
+};
+
+export const ChevronRight: VFC<Props> = (props) => {
+  return (
+    <svg className={props.className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+      <path
+        fillRule="evenodd"
+        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+};
+
+// Propsのデフォルト値
+ChevronRight.defaultProps = {
+  className: "w-5 h-5",
+  disabled: false,
+};

--- a/src/components/icon/XIcon.tsx
+++ b/src/components/icon/XIcon.tsx
@@ -2,7 +2,6 @@ import type { VFC } from "react";
 
 type Props = {
   className?: string;
-  disabled?: boolean;
 };
 
 export const XIcon: VFC<Props> = (props) => {
@@ -22,5 +21,4 @@ export const XIcon: VFC<Props> = (props) => {
 // Propsのデフォルト値
 XIcon.defaultProps = {
   className: "w-5 h-5",
-  disabled: false,
 };

--- a/src/components/icon/XIcon.tsx
+++ b/src/components/icon/XIcon.tsx
@@ -1,0 +1,26 @@
+import type { VFC } from "react";
+
+type Props = {
+  className?: string;
+  disabled?: boolean;
+};
+
+export const XIcon: VFC<Props> = (props) => {
+  return (
+    <svg
+      className={props.className}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+    </svg>
+  );
+};
+
+// Propsのデフォルト値
+XIcon.defaultProps = {
+  className: "w-5 h-5",
+  disabled: false,
+};

--- a/src/pages/license.tsx
+++ b/src/pages/license.tsx
@@ -1,0 +1,7 @@
+import type { NextPage } from "next";
+
+const License: NextPage = () => {
+  return <div>License</div>;
+};
+
+export default License;

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -60,18 +60,18 @@ const Settings: NextPage = () => {
         <span className="block text-center w-full text-xl font-bold">マイページ</span>
       </p>
 
-      <ul>
+      <ul className="space-y-10">
         {MENUS.map((menu) => {
           return (
             <li key={menu.category}>
-              <p className="mt-6 py-2 text-gray-400 font-bold">{menu.category}</p>
-              <ul>
+              <p className="py-2 text-gray-400 font-bold">{menu.category}</p>
+              <ul className="space-y-6">
                 {menu.details.map((detail) => {
                   return (
                     <li key={detail.link}>
                       <Link href={detail.link}>
-                        <a className="flex justify-between items-center mb-3">
-                          <div className="mt-2 font-bold text-lg">{detail.name}</div>
+                        <a className="flex justify-between items-center">
+                          <div className="font-bold text-lg">{detail.name}</div>
                           <ChevronRight />
                         </a>
                       </Link>
@@ -84,11 +84,11 @@ const Settings: NextPage = () => {
         })}
 
         <li>
-          <p className="mt-6 py-2 text-gray-400 font-bold">アクション</p>
-          <ul>
+          <p className="py-2 text-gray-400 font-bold">アクション</p>
+          <ul className="space-y-6">
             <li>
-              <div className="flex justify-between items-center mb-3">
-                <div className="mt-3 font-bold text-lg">ダークモード</div>
+              <div className="flex justify-between items-center">
+                <div className="font-bold text-lg">ダークモード</div>
                 <div className="relative inline-block w-10 mr-2 align-middle select-none transition duration-200 ease-in">
                   <label
                     htmlFor="darkmode"
@@ -105,7 +105,7 @@ const Settings: NextPage = () => {
               </div>
             </li>
             <li>
-              <div className="mt-3 font-bold text-lg text-red-500">ログアウト</div>
+              <div className="font-bold text-lg text-red-500">ログアウト</div>
             </li>
           </ul>
         </li>

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -3,6 +3,51 @@ import Link from "next/link";
 import { XIcon } from "src/components/icon/XIcon";
 import { ChevronRight } from "src/components/icon/ChevronRight";
 
+type Menu = {
+  category: string;
+  details: {
+    link: string;
+    name: string;
+  }[];
+};
+
+const MENUS: Menu[] = [
+  {
+    category: "設定",
+    details: [
+      {
+        link: "/settings/profile",
+        name: "プロフィール設定",
+      },
+      {
+        link: "/settings/account",
+        name: "アカウント設定",
+      },
+      {
+        link: "/settings/notification",
+        name: "通知設定",
+      },
+    ],
+  },
+  {
+    category: "サポート",
+    details: [
+      {
+        link: "/privacy",
+        name: "プライバシーポリシー",
+      },
+      {
+        link: "/terms",
+        name: "利用規約",
+      },
+      {
+        link: "/license",
+        name: "ライセンス",
+      },
+    ],
+  },
+];
+
 const Settings: NextPage = () => {
   return (
     <div className="max-w-screen-sm mx-auto p-4">
@@ -15,45 +60,25 @@ const Settings: NextPage = () => {
         <span className="block text-center w-full text-xl font-bold">マイページ</span>
       </p>
 
-      <p className="py-2 text-gray-400 font-bold">設定</p>
-      <Link href="/settings/profile">
-        <a className="flex justify-between items-center mb-3">
-          <div className="mt-2 font-bold text-lg">プロフィール設定</div>
-          <ChevronRight />
-        </a>
-      </Link>
-      <Link href="/settings/account">
-        <a className="flex justify-between items-center mb-3">
-          <div className="mt-2 font-bold text-lg">アカウント設定</div>
-          <ChevronRight />
-        </a>
-      </Link>
-      <Link href="/settings/notification">
-        <a className="flex justify-between items-center mb-3">
-          <div className="mt-2 font-bold text-lg">通知設定</div>
-          <ChevronRight />
-        </a>
-      </Link>
-
-      <p className="mt-6 py-2 text-gray-400 font-bold">サポート</p>
-      <Link href="/privacy">
-        <a className="flex justify-between items-center mb-3">
-          <div className="amt-3 font-bold text-lg">プライバシーポリシー</div>
-          <ChevronRight />
-        </a>
-      </Link>
-      <Link href="/terms">
-        <a className="flex justify-between items-center mb-3">
-          <div className="mt-3 font-bold text-lg">利用規約</div>
-          <ChevronRight />
-        </a>
-      </Link>
-      <Link href="/license">
-        <a className="flex justify-between items-center mb-3">
-          <div className="mt-3 font-bold text-lg">ライセンス</div>
-          <ChevronRight />
-        </a>
-      </Link>
+      <ul>
+        {MENUS.map((menu) => (
+          <li key={menu.category}>
+            <p className="mt-6 py-2 text-gray-400 font-bold">{menu.category}</p>
+            <ul>
+              {menu.details.map((detail) => (
+                <li key={detail.link}>
+                  <Link href={detail.link}>
+                    <a className="flex justify-between items-center mb-3">
+                      <div className="mt-2 font-bold text-lg">{detail.name}</div>
+                      <ChevronRight />
+                    </a>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </li>
+        ))}
+      </ul>
 
       <p className="mt-6 py-2 text-gray-400 font-bold">アクション</p>
       <div className="flex justify-between items-center mb-3">

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -1,7 +1,7 @@
 import type { NextPage } from "next";
 import Link from "next/link";
-import { XIcon } from "src/components/icon/XIcon";
 import { ChevronRight } from "src/components/icon/ChevronRight";
+import { XIcon } from "src/components/icon/XIcon";
 
 type Menu = {
   category: string;
@@ -61,39 +61,41 @@ const Settings: NextPage = () => {
       </p>
 
       <ul>
-        {MENUS.map((menu) => (
-          <li key={menu.category}>
-            <p className="mt-6 py-2 text-gray-400 font-bold">{menu.category}</p>
-            <ul>
-              {menu.details.map((detail) => (
-                <li key={detail.link}>
-                  <Link href={detail.link}>
-                    <a className="flex justify-between items-center mb-3">
-                      <div className="mt-2 font-bold text-lg">{detail.name}</div>
-                      <ChevronRight />
-                    </a>
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </li>
-        ))}
+        {MENUS.map((menu) => {
+          return (
+            <li key={menu.category}>
+              <p className="mt-6 py-2 text-gray-400 font-bold">{menu.category}</p>
+              <ul>
+                {menu.details.map((detail) => {
+                  return (
+                    <li key={detail.link}>
+                      <Link href={detail.link}>
+                        <a className="flex justify-between items-center mb-3">
+                          <div className="mt-2 font-bold text-lg">{detail.name}</div>
+                          <ChevronRight />
+                        </a>
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </li>
+          );
+        })}
       </ul>
 
       <p className="mt-6 py-2 text-gray-400 font-bold">アクション</p>
       <div className="flex justify-between items-center mb-3">
         <div className="mt-3 font-bold text-lg">ダークモード</div>
         <div className="relative inline-block w-10 mr-2 align-middle select-none transition duration-200 ease-in">
-          <input
-            type="checkbox"
-            name="toggle"
-            id="darkmode"
-            className="outline-none right-4 checked:right-0 duration-200 ease-in checked:bg-blue-600 absolute block w-6 h-6 rounded-full bg-white border-2 appearance-none cursor-pointer"
-          />
-          <label
-            htmlFor="darkmode"
-            className="block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"
-          ></label>
+          <label htmlFor="darkmode" className="block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer">
+            <input
+              type="checkbox"
+              name="toggle"
+              id="darkmode"
+              className="outline-none right-4 checked:right-0 duration-200 ease-in checked:bg-blue-600 absolute block w-6 h-6 rounded-full bg-white border-2 appearance-none cursor-pointer"
+            />
+          </label>
         </div>
       </div>
       <div className="mt-3 font-bold text-lg text-red-500">ログアウト</div>

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -82,23 +82,34 @@ const Settings: NextPage = () => {
             </li>
           );
         })}
-      </ul>
 
-      <p className="mt-6 py-2 text-gray-400 font-bold">アクション</p>
-      <div className="flex justify-between items-center mb-3">
-        <div className="mt-3 font-bold text-lg">ダークモード</div>
-        <div className="relative inline-block w-10 mr-2 align-middle select-none transition duration-200 ease-in">
-          <label htmlFor="darkmode" className="block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer">
-            <input
-              type="checkbox"
-              name="toggle"
-              id="darkmode"
-              className="outline-none right-4 checked:right-0 duration-200 ease-in checked:bg-blue-600 absolute block w-6 h-6 rounded-full bg-white border-2 appearance-none cursor-pointer"
-            />
-          </label>
-        </div>
-      </div>
-      <div className="mt-3 font-bold text-lg text-red-500">ログアウト</div>
+        <li>
+          <p className="mt-6 py-2 text-gray-400 font-bold">アクション</p>
+          <ul>
+            <li>
+              <div className="flex justify-between items-center mb-3">
+                <div className="mt-3 font-bold text-lg">ダークモード</div>
+                <div className="relative inline-block w-10 mr-2 align-middle select-none transition duration-200 ease-in">
+                  <label
+                    htmlFor="darkmode"
+                    className="block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"
+                  >
+                    <input
+                      type="checkbox"
+                      name="toggle"
+                      id="darkmode"
+                      className="outline-none right-4 checked:right-0 duration-200 ease-in checked:bg-blue-600 absolute block w-6 h-6 rounded-full bg-white border-2 appearance-none cursor-pointer"
+                    />
+                  </label>
+                </div>
+              </div>
+            </li>
+            <li>
+              <div className="mt-3 font-bold text-lg text-red-500">ログアウト</div>
+            </li>
+          </ul>
+        </li>
+      </ul>
     </div>
   );
 };

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -1,7 +1,79 @@
 import type { NextPage } from "next";
+import Link from "next/link";
+import { XIcon } from "src/components/icon/XIcon";
+import { ChevronRight } from "src/components/icon/ChevronRight";
 
 const Settings: NextPage = () => {
-  return <div>Settings</div>;
+  return (
+    <div className="max-w-screen-sm mx-auto p-4">
+      <p className="relative my-4 flex items-center">
+        <Link href="/">
+          <a className="absolute left-1">
+            <XIcon />
+          </a>
+        </Link>
+        <span className="block text-center w-full text-xl font-bold">マイページ</span>
+      </p>
+
+      <p className="py-2 text-gray-400 font-bold">設定</p>
+      <Link href="/settings/profile">
+        <a className="flex justify-between items-center mb-3">
+          <div className="mt-2 font-bold text-lg">プロフィール設定</div>
+          <ChevronRight />
+        </a>
+      </Link>
+      <Link href="/settings/account">
+        <a className="flex justify-between items-center mb-3">
+          <div className="mt-2 font-bold text-lg">アカウント設定</div>
+          <ChevronRight />
+        </a>
+      </Link>
+      <Link href="/settings/notification">
+        <a className="flex justify-between items-center mb-3">
+          <div className="mt-2 font-bold text-lg">通知設定</div>
+          <ChevronRight />
+        </a>
+      </Link>
+
+      <p className="mt-6 py-2 text-gray-400 font-bold">サポート</p>
+      <Link href="/privacy">
+        <a className="flex justify-between items-center mb-3">
+          <div className="amt-3 font-bold text-lg">プライバシーポリシー</div>
+          <ChevronRight />
+        </a>
+      </Link>
+      <Link href="/terms">
+        <a className="flex justify-between items-center mb-3">
+          <div className="mt-3 font-bold text-lg">利用規約</div>
+          <ChevronRight />
+        </a>
+      </Link>
+      <Link href="/license">
+        <a className="flex justify-between items-center mb-3">
+          <div className="mt-3 font-bold text-lg">ライセンス</div>
+          <ChevronRight />
+        </a>
+      </Link>
+
+      <p className="mt-6 py-2 text-gray-400 font-bold">アクション</p>
+      <div className="flex justify-between items-center mb-3">
+        <div className="mt-3 font-bold text-lg">ダークモード</div>
+        <div className="relative inline-block w-10 mr-2 align-middle select-none transition duration-200 ease-in">
+          <input
+            type="checkbox"
+            name="toggle"
+            id="darkmode"
+            className="outline-none right-4 checked:right-0 duration-200 ease-in checked:bg-blue-600 absolute block w-6 h-6 rounded-full bg-white border-2 appearance-none cursor-pointer"
+          />
+          <label
+            htmlFor="darkmode"
+            className="block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"
+          ></label>
+        </div>
+      </div>
+      <div className="mt-3 font-bold text-lg text-red-500">ログアウト</div>
+    </div>
+  );
 };
 
 export default Settings;


### PR DESCRIPTION
# 概要
- マイページ（設定）画面の作成
- アイコンのコンポーネント作成（"×"アイコン、">"アイコン）
- ライセンスページの作成（設定ページにライセンス項目がありましたが、pages配下になかったため追加しました）
# 補足
## 実装していないこと
- ダークモードの切り替え
- ログアウトのモーダル実装
## その他
今回時間の関係で上記実装ができていませんが、Next.js、TailwindCSSの勉強がてらに設定画面の見た目を作ったので初PR出させてもらいました！  
お手数をおかけしますがご確認をお願いいたします！