### PR TITLE
🏷️ バックエンドに合わせて型定義修正

### DIFF
--- a/src/components/SearchHistories.tsx
+++ b/src/components/SearchHistories.tsx
@@ -2,13 +2,13 @@ import type { VFC } from "react";
 import { XIcon } from "src/components/icon/XIcon";
 import { Button } from "src/components/shared/Button";
 import { EXAMPLE_USER_01 } from "src/models/user";
-import type { SearchHistory } from "src/types/types";
+import type { SearchHistoryType } from "src/types/types";
 import useSWR from "swr";
 
 const user = EXAMPLE_USER_01;
 
 export const SearchHistories: VFC = () => {
-  const { data, error, mutate } = useSWR<SearchHistory[]>(`/users/${user.id}/searchHistories`);
+  const { data, error, mutate } = useSWR<SearchHistoryType[]>(`/users/${user.id}/searchHistories`);
 
   if (error) {
     // TODO: 検索結果が取得できなかった場合のエラー処理

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,7 +1,7 @@
 import type { VFC } from "react";
 import { MemoCard } from "src/components/users/MemoCard";
 import { EXAMPLE_USER_01 } from "src/models/user";
-import type { ListNote } from "src/types/types";
+import type { ListNoteType } from "src/types/types";
 import useSWR from "swr";
 
 type Props = { keyword: string };
@@ -24,7 +24,7 @@ export const SearchResults: VFC<Props> = (props) => {
   return (
     <ul className="space-y-1">
       {data.length > 0 ? (
-        data.map((note: ListNote) => {
+        data.map((note: ListNoteType) => {
           return (
             <li key={note.id}>
               <MemoCard note={note} />

--- a/src/components/users/MemoCard.tsx
+++ b/src/components/users/MemoCard.tsx
@@ -1,8 +1,8 @@
 import type { VFC } from "react";
-import type { ListNote } from "src/types/types";
+import type { ListNoteType } from "src/types/types";
 
 type Props = {
-  note: ListNote;
+  note: ListNoteType;
 };
 
 // タイトルの取得（改行コードまでをタイトルとする）
@@ -25,7 +25,7 @@ export const MemoCard: VFC<Props> = (props) => {
       </div>
       <div className="flex flex-row justify-between items-end ">
         <div className="pb-2">
-          <span>{props.note.date}</span>
+          <span>{props.note.updatedOn}</span>
         </div>
         <div>
           {props.note.public ? (

--- a/src/mocks/handlers/notes.ts
+++ b/src/mocks/handlers/notes.ts
@@ -1,6 +1,6 @@
 import { rest } from "msw";
-import type { ListNote, Note } from "src/models/note";
 import { EXAMPLE_MY_NOTE_LIST, EXAMPLE_NOTE, EXAMPLE_OTHER_USER_NOTE_LIST } from "src/models/note";
+import type { ListNoteType, NoteType } from "src/types/types";
 
 export const notesHandlers = [
   // 新しいメモを作成する
@@ -9,28 +9,28 @@ export const notesHandlers = [
   }),
 
   // 特定のメモの情報を取得する
-  rest.get<never, Note, { noteId: string }>("/notes/:noteId", (req, res, ctx) => {
+  rest.get<never, NoteType, { noteId: string }>("/notes/:noteId", (req, res, ctx) => {
     const { noteId } = req.params;
     return res(ctx.delay(1000), ctx.status(200), ctx.json({ ...EXAMPLE_NOTE, id: noteId }));
   }),
 
   // 特定のメモを更新する
-  rest.put<string, Note, { noteId: string }>("/notes/:noteId", (req, res, ctx) => {
+  rest.put<string, NoteType, { noteId: string }>("/notes/:noteId", (req, res, ctx) => {
     const { noteId } = req.params;
-    const body: Pick<Note, "content"> = JSON.parse(req.body);
+    const body: Pick<NoteType, "content"> = JSON.parse(req.body);
     // eslint-disable-next-line no-console
     console.log(body.content);
     return res(ctx.delay(1000), ctx.status(200), ctx.json({ ...EXAMPLE_NOTE, id: noteId }));
   }),
 
   // 特定のメモを削除する
-  rest.delete<never, Pick<Note, "id">, { noteId: string }>("/notes/:noteId", (req, res, ctx) => {
+  rest.delete<never, Pick<NoteType, "id">, { noteId: string }>("/notes/:noteId", (req, res, ctx) => {
     const { noteId } = req.params;
     return res(ctx.delay(1000), ctx.status(200), ctx.json({ id: noteId }));
   }),
 
   // 特定のメモを公開する
-  rest.patch<never, Note, { noteId: string }>("/notes/:noteId/public", (req, res, ctx) => {
+  rest.patch<never, NoteType, { noteId: string }>("/notes/:noteId/public", (req, res, ctx) => {
     const { noteId } = req.params;
     return res(
       ctx.delay(1000),
@@ -40,14 +40,14 @@ export const notesHandlers = [
   }),
 
   // 自分または特定のユーザーのメモ一覧を取得する
-  rest.get<never, ListNote[], { userId: string }>("/users/:userId/notes", (req, res, ctx) => {
+  rest.get<never, ListNoteType[], { userId: string }>("/users/:userId/notes", (req, res, ctx) => {
     const { userId } = req.params;
     const notes = userId === "my" ? EXAMPLE_MY_NOTE_LIST : EXAMPLE_OTHER_USER_NOTE_LIST;
     return res(ctx.delay(1000), ctx.status(200), ctx.json(notes));
   }),
 
   // 自分または特定のユーザーのメモ一覧を検索して取得する
-  rest.get<string, ListNote[], { userId: string; keyword: string }>(
+  rest.get<string, ListNoteType[], { userId: string; keyword: string }>(
     "/users/:userId/notes/search/:keyword",
     (req, res, ctx) => {
       const data =

--- a/src/mocks/handlers/searchHistories.ts
+++ b/src/mocks/handlers/searchHistories.ts
@@ -1,16 +1,16 @@
 import { rest } from "msw";
-import type { SearchHistory } from "src/models/searchHistory";
 import { EXAMPLE_SEARCH_HISTORIES } from "src/models/searchHistory";
+import type { SearchHistoryType } from "src/types/types";
 
 export const searchHistoriesHandlers = [
   // 自分の検索履歴を表示する
-  rest.get<never, SearchHistory[], { userId: string }>("/users/:userId/searchHistories", (_req, res, ctx) => {
+  rest.get<never, SearchHistoryType[], { userId: string }>("/users/:userId/searchHistories", (_req, res, ctx) => {
     return res(ctx.delay(1000), ctx.status(200), ctx.json(EXAMPLE_SEARCH_HISTORIES));
   }),
 
   // 自分の検索履歴に追加する
   rest.post<string, { id: string }, { userId: string }>("/users/:userId/searchHistories", (req, res, ctx) => {
-    const body: Pick<SearchHistory, "keyword"> = JSON.parse(req.body);
+    const body: Pick<SearchHistoryType, "keyword"> = JSON.parse(req.body);
     // eslint-disable-next-line no-console
     console.log(body.keyword);
     return res(ctx.delay(1000), ctx.status(201), ctx.json({ id: "foo" }));

--- a/src/mocks/handlers/users.ts
+++ b/src/mocks/handlers/users.ts
@@ -1,21 +1,21 @@
 import { rest } from "msw";
-import type { User, UserPutRequest } from "src/models/user";
 import { EXAMPLE_USER_01, EXAMPLE_USER_02 } from "src/models/user";
+import type { UserPutRequest, UserType } from "src/types/types";
 
 export const usersHandlers = [
   // ユーザーを作成する
-  rest.post<string, User, never>("/users", (_req, res, ctx) => {
+  rest.post<string, UserType, never>("/users", (_req, res, ctx) => {
     return res(ctx.delay(1000), ctx.status(201), ctx.json(EXAMPLE_USER_01));
   }),
 
   // 特定のユーザーの情報を取得する
-  rest.get<never, User, { userId: string }>("/users/:userId", (req, res, ctx) => {
+  rest.get<never, UserType, { userId: string }>("/users/:userId", (req, res, ctx) => {
     const { userId } = req.params;
     return res(ctx.delay(1000), ctx.status(200), ctx.json({ ...EXAMPLE_USER_01, id: userId }));
   }),
 
   // 特定のユーザー（自分）の情報を更新する
-  rest.put<string, User, { userId: string }>("/users/:userId", (req, res, ctx) => {
+  rest.put<string, UserType, { userId: string }>("/users/:userId", (req, res, ctx) => {
     const { userId } = req.params;
     const body: UserPutRequest = JSON.parse(req.body);
     // eslint-disable-next-line no-console

--- a/src/models/note.ts
+++ b/src/models/note.ts
@@ -1,18 +1,6 @@
-export type Note = {
-  id: string;
-  content: string;
-  public: boolean;
-  date: string;
-};
+import type { ListNoteType, NoteType } from "src/types/types";
 
-export type ListNote = {
-  id: string;
-  excerpt: string;
-  public: boolean;
-  date: string;
-};
-
-export const EXAMPLE_NOTE: Note = {
+export const EXAMPLE_NOTE: NoteType = {
   id: "123",
   content: `書籍を使って学ぶのは本当に必要なのか考察
 
@@ -28,80 +16,79 @@ export const EXAMPLE_NOTE: Note = {
 ただ必ずしもマイナスだらけではなくメリットもある。発行年月日の新しい本で、かつ信頼できる方がオススメしている本であれば、かなり有用だろう。情報が古いということもなく、かつすぐに選ぶこともできるので、純粋にメリットだけを享受できる形になる。
 `,
   public: false,
-  date: "2021/3/1",
 };
 
-export const EXAMPLE_MY_NOTE_LIST: ListNote[] = [
+export const EXAMPLE_MY_NOTE_LIST: ListNoteType[] = [
   {
     id: "5",
     excerpt: `書籍を使って学ぶのは本当に必要なのか考察
     最初にプログラミングはどうやって学ぶべきか考えてみた。公式ドキュメ`,
     public: false,
-    date: "2020/10/11",
+    updatedOn: "2020/10/11",
   },
   {
     id: "4",
     excerpt: `HTML・CSS・JavaScriptの実践
     構文を学んだけど使えるか分からないので、実際にレイアウトを組んでみた。今回は`,
     public: true,
-    date: "2020/12/11",
+    updatedOn: "2020/12/11",
   },
   {
     id: "3",
     excerpt: `3年後にどうなっていたいかを考えてみた
     プログラミングの勉強はいったん休みにして、将来どうなりたいかを真剣に考`,
     public: false,
-    date: "2021/2/1",
+    updatedOn: "2021/2/1",
   },
   {
     id: "2",
     excerpt: `TypeScriptが何か調べてみた
     開発するときに型があると便利らしい。JavaScriptは型が無いので、それを補うために`,
     public: false,
-    date: "2021/3/1",
+    updatedOn: "2021/3/1",
   },
   {
     id: "1",
     excerpt: `Reactのチュートリアルを学んでみた感想
     正直難しかったので、明日ももう一回同じところをやってみようと思う`,
     public: true,
-    date: "2021/3/20",
+    updatedOn: "2021/3/20",
   },
 ];
 
-export const EXAMPLE_OTHER_USER_NOTE_LIST: ListNote[] = [
+export const EXAMPLE_OTHER_USER_NOTE_LIST: ListNoteType[] = [
   {
     id: "5",
     excerpt: `昔々あるところに、おじいさんとおばあさんがいました
     おじいさんは山へ芝刈りに、おばあさんは川へ洗濯へ。すると`,
     public: false,
-    date: "2020/10/11",
+    updatedOn: "2020/10/11",
   },
   {
     id: "4",
     excerpt: `むかしむかし、ある村に、心のやさしい浦島太郎(うらしまたろう)という
     若者がいました。浦島(うらしま)さんが海辺を`,
     public: true,
-    date: "2020/10/21",
+    updatedOn: "2020/10/21",
   },
   {
     id: "3",
     excerpt: `むかしむかし、足柄山に金太郎という元気な男の子が乳母と一緒に暮らしていました。金太郎は小さい時からクマやサル`,
     public: true,
-    date: "2020/12/11",
+    updatedOn: "2020/12/11",
   },
   {
     id: "2",
     excerpt: `蟹がおにぎりを持って歩いていると、ずる賢い猿が、
     拾った柿の種と交換しようと言ってきた。蟹は最初は嫌がったが、「`,
     public: false,
-    date: "2021/01/15",
+    updatedOn: "2021/01/15",
   },
   {
     id: "1",
     excerpt: `ある村に一人の男の子が産まれたが、その子は大人の
     小指ほどの大きさしかなかった。それでも両親は一寸法師と名付け`,
     public: true,
-    date: "2021/02/20",
+    updatedOn: "2021/02/20",
   },
 ];

--- a/src/models/searchHistory.ts
+++ b/src/models/searchHistory.ts
@@ -1,9 +1,6 @@
-export type SearchHistory = {
-  id: number;
-  keyword: string;
-};
+import type { SearchHistoryType } from "src/types/types";
 
-export const EXAMPLE_SEARCH_HISTORIES: SearchHistory[] = [
+export const EXAMPLE_SEARCH_HISTORIES: SearchHistoryType[] = [
   { id: 3, keyword: "Vue.js" },
   { id: 2, keyword: "React" },
   { id: 1, keyword: "JavaScript" },

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,26 +1,20 @@
-export type User = {
-  id: string;
-  name: string;
-  avatarUrl: string;
-};
+import type { UserPutRequest, UserType } from "src/types/types";
 
-export type UserPutRequest = User | Pick<User, "id" | "name"> | Pick<User, "id" | "avatarUrl">;
-
-export const hasName = (user: UserPutRequest): user is User | Pick<User, "id" | "name"> => {
+export const hasName = (user: UserPutRequest): user is UserType | Pick<UserType, "id" | "name"> => {
   return "name" in user;
 };
 
-export const hasAvatarUrl = (user: UserPutRequest): user is User | Pick<User, "id" | "avatarUrl"> => {
+export const hasAvatarUrl = (user: UserPutRequest): user is UserType | Pick<UserType, "id" | "avatarUrl"> => {
   return "avatarUrl" in user;
 };
 
-export const EXAMPLE_USER_01: User = {
+export const EXAMPLE_USER_01: UserType = {
   id: "qinta",
   name: "秦太",
   avatarUrl: "/mocks/avatar01.jpg",
 };
 
-export const EXAMPLE_USER_02: User = {
+export const EXAMPLE_USER_02: UserType = {
   id: "qinko",
   name: "秦子",
   avatarUrl: "/mocks/avatar02.jpg",

--- a/src/pages/async.tsx
+++ b/src/pages/async.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable no-console */
 import type { NextPage } from "next";
 import { Layout } from "src/components/layout";
-import type { User, UserPutRequest } from "src/models/user";
+import type { UserPutRequest, UserType } from "src/types/types";
 import useSWR from "swr";
 
 const Async: NextPage = () => {
-  const { data, error } = useSWR<User>("/users/foo");
+  const { data, error } = useSWR<UserType>("/users/foo");
 
   const handleClick = async () => {
     const req: UserPutRequest = { id: "foo", name: "秦子" };

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -9,7 +9,7 @@ import { SearchResults } from "src/components/SearchResults";
 import { Button } from "src/components/shared/Button";
 import { InputText } from "src/components/shared/InputText";
 import { EXAMPLE_USER_01 } from "src/models/user";
-import type { SearchHistory } from "src/types/types";
+import type { SearchHistoryType } from "src/types/types";
 
 // **********************************
 // ユーザ情報はログイン時に取得している想定のため、一旦固定値にする
@@ -27,7 +27,7 @@ const Search: NextPage = () => {
   const handleSubmit: DOMAttributes<HTMLFormElement>["onSubmit"] = async (e) => {
     e.preventDefault();
     setKeyword(value);
-    const req: Pick<SearchHistory, "keyword"> = { keyword };
+    const req: Pick<SearchHistoryType, "keyword"> = { keyword };
     await fetch(`/users/${user.id}/searchHistories`, {
       method: "post",
       body: JSON.stringify(req),

--- a/src/pages/users/[userId].tsx
+++ b/src/pages/users/[userId].tsx
@@ -6,7 +6,7 @@ import { Button } from "src/components/shared/Button";
 import { InputText } from "src/components/shared/InputText";
 import { MemoCard } from "src/components/users/MemoCard";
 import { EXAMPLE_USER_01 } from "src/models/user";
-import type { ListNote } from "src/types/types";
+import type { ListNoteType } from "src/types/types";
 import useSWR from "swr";
 
 // **********************************
@@ -15,7 +15,7 @@ import useSWR from "swr";
 const user = EXAMPLE_USER_01;
 
 const User: NextPage = () => {
-  const { data: listNote, error } = useSWR<ListNote[]>(`/users/${user.id}/notes`);
+  const { data: listNote, error } = useSWR<ListNoteType[]>(`/users/${user.id}/notes`);
 
   return (
     <div className="flex flex-col overscroll-none h-screen">
@@ -61,7 +61,7 @@ const User: NextPage = () => {
         {error ? <div>メモが登録されていません</div> : null}
         {listNote ? (
           <div className="w-full flex flex-col h-full">
-            {listNote.map((note: ListNote) => {
+            {listNote.map((note: ListNoteType) => {
               return <MemoCard key={note.id} note={note} />;
             })}
           </div>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,23 +1,25 @@
-export type User = {
+export type UserType = {
   id: string;
   name: string;
   avatarUrl: string;
 };
-export type Note = {
+
+export type UserPutRequest = UserType | Pick<UserType, "id" | "name"> | Pick<UserType, "id" | "avatarUrl">;
+
+export type NoteType = {
   id: string;
   content: string;
   public: boolean;
-  date: string;
 };
 
-export type ListNote = {
+export type ListNoteType = {
   id: string;
   excerpt: string;
   public: boolean;
-  date: string;
+  updatedOn: string;
 };
 
-export type SearchHistory = {
+export type SearchHistoryType = {
   id: number;
   keyword: string;
 };


### PR DESCRIPTION
# 概要
バックエンドでの定義に合わせて、型の定義を修正しました。
型の定義変更のみで、ロジックの修正は行ってません。

# 修正内容
- 下記の修正内容を元に、更新日付の変数名をupdatedOnとしました。
https://github.com/qin-salon/qin-memo-backend/blob/7c2ca40edd9c74f192b4121355c96b30a71fa99c/src/types/user/note-excerpt.d.ts#L8
- 下記の型を元に、変数dateを削除しました。
https://github.com/qin-salon/qin-memo-backend/blob/7c2ca40edd9c74f192b4121355c96b30a71fa99c/src/types/note/note.d.ts#L8
- src/models配下に定義されていた型を削除して、全てsrc/typesで定義するようにしました。
- 型の名称として定義されていた「Note」がpages/notes/[noteId].tsxのコンポーネント名と被っていたので、「NoteType」と変更しました。
- 型の名称として定義されていた「User」がpages/users/[userId].tsxのコンポーネント名と被っていたので、「UserType」と変更しました。
- 各コンポーネントで使用されている型定義の修正を行いました。（yarn buildでエラーがない事を確認しました。）